### PR TITLE
Add selection range highlighting

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -189,3 +189,24 @@ MISC
 
 
 
+
+VISIBLE SELECTION OVERLAY
+
+- should be its own layer on the canvas
+
+- needs to know the origin point of the selection and the current end of the selection. We can call those selectionStart and selectionEnd?
+
+- what are the conditions for a selection rect to be rendered? Shift + click enters selection mode?
+
+
+
+- in the components state, have shiftKeyPressed and mouseIsDown properties. shiftKeyPressed is set to true when shift key is pressed, and then set to false again when shift key is released. mouseIsDown is set to true onMouseDown and then set to false onMouseUp.
+
+
+
+- I will need to add incorporate the selection overlay into the notes layer. So I should turn this into a class based component and move over the necessary logic from the selection overlay layer I was previously working on. 
+
+
+
+
+

--- a/TODO.md
+++ b/TODO.md
@@ -180,7 +180,6 @@ MISC
 
 - review the tools usage throughout the composer and piano roll components. Does the pencil tool need to be seperate or could it be integrated into the main tool?
 
-- add a visual effect when selecting a range via dragging - a tinted overlay should appear over the area covered by the drag. 
 
 - begin to think about better components for the instrument and effects interfaces. A dial would probably be better than using range inputs. It should also have an accompanying text input where the user can manually type in the new value, and also shift clicking (or alt clicking) the dial should reset it to a default value. To calculate the value will probably involve determining the angle the dial is turned to, via the pythagorean theorem and trigonometric functions. 
 

--- a/src/components/Composer/Composer.js
+++ b/src/components/Composer/Composer.js
@@ -15,6 +15,7 @@ const Composer = props => (
         className="composer__container"
         tabIndex="-1"
         onKeyDown={props.handleKeyDown}
+        onKeyUp={props.handleKeyUp}
         style={{outline: 'none'}}
     >
         <ComposerControls 
@@ -69,6 +70,9 @@ const Composer = props => (
                         currentlySelectedSections={props.currentlySelectedSections}
                         handleSectionClick={props.handleSectionClick}
                         handleSectionDoubleClick={props.handleSectionDoubleClick}
+                        canvasWidth={props.canvasWidth}
+                        canvasHeight={props.canvasHeight}
+                        shiftKeyPressed={props.shiftKeyPressed}
                     />
                     <TransportLayer 
                         transportLayerRef={props.transportLayerRef}
@@ -111,11 +115,13 @@ Composer.propTypes = {
     // constructed arrays
     gridLinesArray: PropTypes.arrayOf(PropTypes.array).isRequired,
     sectionRectsArray: PropTypes.arrayOf(PropTypes.object).isRequired,
-    // input values
+    // values from state
     cursorValue: PropTypes.string.isRequired,
     durationValue: PropTypes.number.isRequired,
+    shiftKeyPressed: PropTypes.bool.isRequired,
     // callback functions
     handleKeyDown: PropTypes.func.isRequired,
+    handleKeyUp: PropTypes.func.isRequired,
     updateCursorValue: PropTypes.func.isRequired,
     updateDurationValue: PropTypes.func.isRequired,
     handleStageClick: PropTypes.func.isRequired,

--- a/src/components/Composer/Composer.js
+++ b/src/components/Composer/Composer.js
@@ -9,6 +9,7 @@ import SectionsLayer from './SectionsLayer';
 import TransportLayer from './TransportLayer';
 import SeekerLayer from './SeekerLayer';
 import ScrollBarLayer from './ScrollBarLayer';
+import SelectionOverlayEnhancer from '../SelectionOverlayEnhancer'
 
 const Composer = props => (
     <div 
@@ -64,7 +65,9 @@ const Composer = props => (
                         canvasHeight={props.canvasHeight}
                         gridLinesArray={props.gridLinesArray}
                     />
-                    <SectionsLayer 
+                    <SelectionOverlayEnhancer
+                        childLayerRef={props.sectionsLayerRef}
+                        shiftKeyPressed={props.shiftKeyPressed}
                         sectionsLayerRef={props.sectionsLayerRef}
                         sectionRectsArray={props.sectionRectsArray}
                         currentlySelectedSections={props.currentlySelectedSections}
@@ -72,8 +75,9 @@ const Composer = props => (
                         handleSectionDoubleClick={props.handleSectionDoubleClick}
                         canvasWidth={props.canvasWidth}
                         canvasHeight={props.canvasHeight}
-                        shiftKeyPressed={props.shiftKeyPressed}
-                    />
+                    >
+                        {props => <SectionsLayer {...props} />}
+                    </SelectionOverlayEnhancer>
                     <TransportLayer 
                         transportLayerRef={props.transportLayerRef}
                         canvasWidth={props.canvasWidth}

--- a/src/components/Composer/Composer.test.js
+++ b/src/components/Composer/Composer.test.js
@@ -59,6 +59,7 @@ test('renders correctly', () => {
             cursorValue={'pointer'}
             durationValue={4}
             handleKeyDown={jest.fn()}
+            handleKeyUp={jest.fn()}
             updateCursorValue={jest.fn()}
             updateDurationValue={jest.fn()}
             handleStageClick={jest.fn()}
@@ -74,6 +75,7 @@ test('renders correctly', () => {
             channels={channelsState}
             currentlySelectedSections={[]}
             currentlySelectedChannel='6984087700822156'
+            shiftKeyPressed={false}
         />
     );
     expect(component).toMatchSnapshot();

--- a/src/components/Composer/SectionsLayer.js
+++ b/src/components/Composer/SectionsLayer.js
@@ -1,141 +1,53 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Layer, Rect } from 'react-konva';
 import { UIColors } from '../../constants';
-import { adjustForScroll } from '../../sharedUtils';
 
-class SectionsLayer extends Component {
-    constructor(props) {
-        super(props);
-        this.overlayRectRef = React.createRef();
-        this.state = {
-            mouseIsDown: false,
-            mouseDownPosX: 0,
-            mouseDownPosY: 0,
-        };
-    }
-
-    handleMouseDown = (e) => {
-        this.setState({
-            mouseIsDown: true,
-            mouseDownPosX: adjustForScroll({ raw: e.evt.layerX, scroll: this.props.sectionsLayerRef.current.attrs.x }),
-            mouseDownPosY: adjustForScroll({ raw: e.evt.layerY, scroll: this.props.sectionsLayerRef.current.attrs.y })
-        });
-    }
-
-    handleMouseUp = (e) => {
-        this.setState({
-            mouseIsDown: false,
-            mouseDownPosX: 0,
-            mouseDownPosY: 0,
-            currentMousePosX: 0,
-            currentMousePosY: 0
-        });
-        const overlay = this.overlayRectRef.current;
-        overlay.x(0);
-        overlay.y(0);
-        overlay.width(0);
-        overlay.height(0);
-        this.props.sectionsLayerRef.current.batchDraw();
-    }
-
-    handleMouseMove = (e) => {
-        if (this.state.mouseIsDown && this.props.shiftKeyPressed) {
-            const currentMousePosX = adjustForScroll({ raw: e.evt.layerX, scroll: this.props.sectionsLayerRef.current.attrs.x });
-            const currentMousePosY = adjustForScroll({ raw: e.evt.layerY, scroll: this.props.sectionsLayerRef.current.attrs.y });
-            const { x, y, width, height } = this.getOverlayPosition({
-                mouseDownPosX: this.state.mouseDownPosX,
-                mouseDownPosY: this.state.mouseDownPosY,
-                currentMousePosX,
-                currentMousePosY,
-            });
-            const overlay = this.overlayRectRef.current;
-            overlay.x(x);
-            overlay.y(y);
-            overlay.width(width);
-            overlay.height(height);
-            this.props.sectionsLayerRef.current.batchDraw();
-        }
-    }
-
-    getOverlayPosition = (optionsObject) => {
-        const {
-            mouseDownPosX,
-            mouseDownPosY,
-            currentMousePosX,
-            currentMousePosY
-        } = optionsObject;
-        if (
-            mouseDownPosX === 0 && mouseDownPosY === 0 && 
-            currentMousePosX === 0 && currentMousePosY === 0
-        ) {
-            return {
-                x: 0,
-                y: 0,
-                width: 0,
-                height: 0
-            };
-        }
-        const leftBound = Math.min(mouseDownPosX, currentMousePosX);
-        const rightBound = Math.max(mouseDownPosX, currentMousePosX);
-        const topBound = Math.min(mouseDownPosY, currentMousePosY);
-        const bottomBound = Math.max(mouseDownPosY, currentMousePosY);
-        const width = rightBound - leftBound;
-        const height = bottomBound - topBound;
-        return {
-            x: leftBound,
-            y: topBound,
-            width,
-            height
-        };
-    }
-
-    render() {
-        const clickTargetHeight = Math.max(document.documentElement.clientHeight, this.props.canvasHeight);
-        return (
-            <Layer 
-                ref={this.props.sectionsLayerRef}
-                onMouseDown={this.handleMouseDown}
-                onMouseUp={this.handleMouseUp}
-                onMouseMove={this.handleMouseMove}    
-            >
-                <Rect 
-                    width={this.props.canvasWidth}
-                    height={clickTargetHeight}
-                    x={0}
-                    y={0}
-                />
-                {
-                    this.props.sectionRectsArray.map((section, index) => (
-                        <Rect 
-                            x={section.x}
-                            y={section.y}
-                            sectionId={section.sectionId}
-                            height={section.height}
-                            width={section.width}
-                            fill={
-                                this.props.currentlySelectedSections.includes(section.sectionId) ? 
-                                UIColors.darkGrey :
-                                section.color
-                            }
-                            stroke={UIColors.offWhite}
-                            strokeWidth={2}
-                            type={'section'}
-                            key={index}
-                            onClick={(e) => this.props.handleSectionClick(e, section.sectionId)}
-                            onDblClick={(e) => this.props.handleSectionDoubleClick(e, section.sectionId)}
-                        />
-                    ))
-                } 
-                <Rect 
-                    ref={this.overlayRectRef}
-                    fill="#08b5d3"
-                    opacity={0.4}
-                    cornerRadius={3}
-                />
-            </Layer>
-        );
-    }
+const SectionsLayer = props => {
+    const clickTargetHeight = Math.max(document.documentElement.clientHeight, props.canvasHeight);
+    return (
+        <Layer 
+            ref={props.sectionsLayerRef}
+            onMouseDown={props.handleMouseDown}
+            onMouseUp={props.handleMouseUp}
+            onMouseMove={props.handleMouseMove}    
+        >
+            <Rect 
+                width={props.canvasWidth}
+                height={clickTargetHeight}
+                x={0}
+                y={0}
+            />
+            {
+                props.sectionRectsArray.map((section, index) => (
+                    <Rect 
+                        x={section.x}
+                        y={section.y}
+                        sectionId={section.sectionId}
+                        height={section.height}
+                        width={section.width}
+                        fill={
+                            props.currentlySelectedSections.includes(section.sectionId) ? 
+                            UIColors.darkGrey :
+                            section.color
+                        }
+                        stroke={UIColors.offWhite}
+                        strokeWidth={2}
+                        type={'section'}
+                        key={index}
+                        onClick={(e) => props.handleSectionClick(e, section.sectionId)}
+                        onDblClick={(e) => props.handleSectionDoubleClick(e, section.sectionId)}
+                    />
+                ))
+            } 
+            <Rect 
+                ref={props.overlayRectRef}
+                fill="#08b5d3"
+                opacity={0.4}
+                cornerRadius={3}
+            />
+        </Layer>
+    );
 }
 
 SectionsLayer.propTypes = {
@@ -146,7 +58,10 @@ SectionsLayer.propTypes = {
     handleSectionDoubleClick: PropTypes.func.isRequired,
     canvasHeight: PropTypes.number.isRequired,
     canvasWidth: PropTypes.number.isRequired,
-    shiftKeyPressed: PropTypes.bool.isRequired
+    handleMouseDown: PropTypes.func.isRequired,
+    handleMouseUp: PropTypes.func.isRequired,
+    handleMouseMove: PropTypes.func.isRequired,
+    overlayRectRef: PropTypes.object.isRequired
 };
 
 export default SectionsLayer;

--- a/src/components/Composer/SectionsLayer.js
+++ b/src/components/Composer/SectionsLayer.js
@@ -1,41 +1,152 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Layer, Rect } from 'react-konva';
 import { UIColors } from '../../constants';
+import { adjustForScroll } from '../../sharedUtils';
 
-const SectionsLayer = props => (
-    <Layer ref={props.sectionsLayerRef}>
-        {
-            props.sectionRectsArray.map((section, index) => (
+class SectionsLayer extends Component {
+    constructor(props) {
+        super(props);
+        this.overlayRectRef = React.createRef();
+        this.state = {
+            mouseIsDown: false,
+            mouseDownPosX: 0,
+            mouseDownPosY: 0,
+        };
+    }
+
+    handleMouseDown = (e) => {
+        this.setState({
+            mouseIsDown: true,
+            mouseDownPosX: adjustForScroll({ raw: e.evt.layerX, scroll: this.props.sectionsLayerRef.current.attrs.x }),
+            mouseDownPosY: adjustForScroll({ raw: e.evt.layerY, scroll: this.props.sectionsLayerRef.current.attrs.y })
+        });
+    }
+
+    handleMouseUp = (e) => {
+        this.setState({
+            mouseIsDown: false,
+            mouseDownPosX: 0,
+            mouseDownPosY: 0,
+            currentMousePosX: 0,
+            currentMousePosY: 0
+        });
+        const overlay = this.overlayRectRef.current;
+        overlay.x(0);
+        overlay.y(0);
+        overlay.width(0);
+        overlay.height(0);
+        this.props.sectionsLayerRef.current.batchDraw();
+    }
+
+    handleMouseMove = (e) => {
+        if (this.state.mouseIsDown && this.props.shiftKeyPressed) {
+            const currentMousePosX = adjustForScroll({ raw: e.evt.layerX, scroll: this.props.sectionsLayerRef.current.attrs.x });
+            const currentMousePosY = adjustForScroll({ raw: e.evt.layerY, scroll: this.props.sectionsLayerRef.current.attrs.y });
+            const { x, y, width, height } = this.getOverlayPosition({
+                mouseDownPosX: this.state.mouseDownPosX,
+                mouseDownPosY: this.state.mouseDownPosY,
+                currentMousePosX,
+                currentMousePosY,
+            });
+            const overlay = this.overlayRectRef.current;
+            overlay.x(x);
+            overlay.y(y);
+            overlay.width(width);
+            overlay.height(height);
+            this.props.sectionsLayerRef.current.batchDraw();
+        }
+    }
+
+    getOverlayPosition = (optionsObject) => {
+        const {
+            mouseDownPosX,
+            mouseDownPosY,
+            currentMousePosX,
+            currentMousePosY
+        } = optionsObject;
+        if (
+            mouseDownPosX === 0 && mouseDownPosY === 0 && 
+            currentMousePosX === 0 && currentMousePosY === 0
+        ) {
+            return {
+                x: 0,
+                y: 0,
+                width: 0,
+                height: 0
+            };
+        }
+        const leftBound = Math.min(mouseDownPosX, currentMousePosX);
+        const rightBound = Math.max(mouseDownPosX, currentMousePosX);
+        const topBound = Math.min(mouseDownPosY, currentMousePosY);
+        const bottomBound = Math.max(mouseDownPosY, currentMousePosY);
+        const width = rightBound - leftBound;
+        const height = bottomBound - topBound;
+        return {
+            x: leftBound,
+            y: topBound,
+            width,
+            height
+        };
+    }
+
+    render() {
+        const clickTargetHeight = Math.max(document.documentElement.clientHeight, this.props.canvasHeight);
+        return (
+            <Layer 
+                ref={this.props.sectionsLayerRef}
+                onMouseDown={this.handleMouseDown}
+                onMouseUp={this.handleMouseUp}
+                onMouseMove={this.handleMouseMove}    
+            >
                 <Rect 
-                    x={section.x}
-                    y={section.y}
-                    sectionId={section.sectionId}
-                    height={section.height}
-                    width={section.width}
-                    fill={
-                        props.currentlySelectedSections.includes(section.sectionId) ? 
-                        UIColors.darkGrey :
-                        section.color
-                    }
-                    stroke={UIColors.offWhite}
-                    strokeWidth={2}
-                    type={'section'}
-                    key={index}
-                    onClick={(e) => props.handleSectionClick(e, section.sectionId)}
-                    onDblClick={(e) => props.handleSectionDoubleClick(e, section.sectionId)}
+                    width={this.props.canvasWidth}
+                    height={clickTargetHeight}
+                    x={0}
+                    y={0}
                 />
-            ))
-        } 
-    </Layer>
-);
+                {
+                    this.props.sectionRectsArray.map((section, index) => (
+                        <Rect 
+                            x={section.x}
+                            y={section.y}
+                            sectionId={section.sectionId}
+                            height={section.height}
+                            width={section.width}
+                            fill={
+                                this.props.currentlySelectedSections.includes(section.sectionId) ? 
+                                UIColors.darkGrey :
+                                section.color
+                            }
+                            stroke={UIColors.offWhite}
+                            strokeWidth={2}
+                            type={'section'}
+                            key={index}
+                            onClick={(e) => this.props.handleSectionClick(e, section.sectionId)}
+                            onDblClick={(e) => this.props.handleSectionDoubleClick(e, section.sectionId)}
+                        />
+                    ))
+                } 
+                <Rect 
+                    ref={this.overlayRectRef}
+                    fill="#08b5d3"
+                    opacity={0.4}
+                    cornerRadius={3}
+                />
+            </Layer>
+        );
+    }
+}
 
 SectionsLayer.propTypes = {
     sectionsLayerRef: PropTypes.object.isRequired,
     sectionRectsArray: PropTypes.arrayOf(PropTypes.object).isRequired,
     currentlySelectedSections: PropTypes.arrayOf(PropTypes.string).isRequired,
     handleSectionClick: PropTypes.func.isRequired,
-    handleSectionDoubleClick: PropTypes.func.isRequired
+    handleSectionDoubleClick: PropTypes.func.isRequired,
+    canvasHeight: PropTypes.number.isRequired,
+    canvasWidth: PropTypes.number.isRequired,
+    shiftKeyPressed: PropTypes.bool.isRequired
 };
 
 export default SectionsLayer;

--- a/src/components/Composer/SectionsLayer.test.js
+++ b/src/components/Composer/SectionsLayer.test.js
@@ -40,6 +40,9 @@ test('renders correctly', () => {
             handleSectionDoubleClick={jest.fn()}
             sectionRectsArray={sectionRectsArray}
             currentlySelectedSections={[]}
+            canvasHeight={320}
+            canvasWidth={1200}
+            shiftKeyPressed={false}
         />
     );
     expect(component).toMatchSnapshot();
@@ -53,6 +56,9 @@ test('renders selected and unselected sections with different fill colors', () =
             handleSectionDoubleClick={jest.fn()}
             sectionRectsArray={sectionRectsArray}
             currentlySelectedSections={[]}
+            canvasHeight={320}
+            canvasWidth={1200}
+            shiftKeyPressed={false}
         />
     );
     const withSelection = shallow(
@@ -62,6 +68,9 @@ test('renders selected and unselected sections with different fill colors', () =
             handleSectionDoubleClick={jest.fn()}
             sectionRectsArray={sectionRectsArray}
             currentlySelectedSections={['7009247242625234']}
+            canvasHeight={320}
+            canvasWidth={1200}
+            shiftKeyPressed={false}
         />
     );
     expect(noSelection.find({ sectionId: '7009247242625234' }).props().fill)

--- a/src/components/Composer/SectionsLayer.test.js
+++ b/src/components/Composer/SectionsLayer.test.js
@@ -42,7 +42,10 @@ test('renders correctly', () => {
             currentlySelectedSections={[]}
             canvasHeight={320}
             canvasWidth={1200}
-            shiftKeyPressed={false}
+            handleMouseDown={jest.fn()}
+            handleMouseUp={jest.fn()}
+            handleMouseMove={jest.fn()}
+            overlayRectRef={React.createRef()}
         />
     );
     expect(component).toMatchSnapshot();
@@ -58,7 +61,10 @@ test('renders selected and unselected sections with different fill colors', () =
             currentlySelectedSections={[]}
             canvasHeight={320}
             canvasWidth={1200}
-            shiftKeyPressed={false}
+            handleMouseDown={jest.fn()}
+            handleMouseUp={jest.fn()}
+            handleMouseMove={jest.fn()}
+            overlayRectRef={React.createRef()}
         />
     );
     const withSelection = shallow(
@@ -70,7 +76,10 @@ test('renders selected and unselected sections with different fill colors', () =
             currentlySelectedSections={['7009247242625234']}
             canvasHeight={320}
             canvasWidth={1200}
-            shiftKeyPressed={false}
+            handleMouseDown={jest.fn()}
+            handleMouseUp={jest.fn()}
+            handleMouseMove={jest.fn()}
+            overlayRectRef={React.createRef()}
         />
     );
     expect(noSelection.find({ sectionId: '7009247242625234' }).props().fill)

--- a/src/components/Composer/__snapshots__/Composer.test.js.snap
+++ b/src/components/Composer/__snapshots__/Composer.test.js.snap
@@ -1310,9 +1310,14 @@ exports[`renders correctly 1`] = `
             ]
           }
         />
-        <SectionsLayer
+        <SelectionOverlayEnhancer
           canvasHeight={320}
           canvasWidth={9600}
+          childLayerRef={
+            Object {
+              "current": null,
+            }
+          }
           currentlySelectedSections={Array []}
           handleSectionClick={[MockFunction]}
           handleSectionDoubleClick={[MockFunction]}
@@ -1334,7 +1339,9 @@ exports[`renders correctly 1`] = `
             }
           }
           shiftKeyPressed={false}
-        />
+        >
+          <Component />
+        </SelectionOverlayEnhancer>
         <TransportLayer
           canvasWidth={9600}
           transportLayerRef={

--- a/src/components/Composer/__snapshots__/Composer.test.js.snap
+++ b/src/components/Composer/__snapshots__/Composer.test.js.snap
@@ -4,6 +4,7 @@ exports[`renders correctly 1`] = `
 <div
   className="composer__container"
   onKeyDown={[MockFunction]}
+  onKeyUp={[MockFunction]}
   style={
     Object {
       "outline": "none",
@@ -1310,6 +1311,8 @@ exports[`renders correctly 1`] = `
           }
         />
         <SectionsLayer
+          canvasHeight={320}
+          canvasWidth={9600}
           currentlySelectedSections={Array []}
           handleSectionClick={[MockFunction]}
           handleSectionDoubleClick={[MockFunction]}
@@ -1330,6 +1333,7 @@ exports[`renders correctly 1`] = `
               "current": null,
             }
           }
+          shiftKeyPressed={false}
         />
         <TransportLayer
           canvasWidth={9600}

--- a/src/components/Composer/__snapshots__/ComposerContainer.test.js.snap
+++ b/src/components/Composer/__snapshots__/ComposerContainer.test.js.snap
@@ -1268,6 +1268,7 @@ exports[`renders correctly 1`] = `
     ]
   }
   handleKeyDown={[Function]}
+  handleKeyUp={[Function]}
   handleScrollBarClickEvents={[Function]}
   handleSectionClick={[Function]}
   handleSectionDoubleClick={[Function]}
@@ -1303,6 +1304,7 @@ exports[`renders correctly 1`] = `
       "current": null,
     }
   }
+  shiftKeyPressed={false}
   stageHeight={-104}
   stageRef={
     Object {

--- a/src/components/Composer/__snapshots__/SectionsLayer.test.js.snap
+++ b/src/components/Composer/__snapshots__/SectionsLayer.test.js.snap
@@ -1,7 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<Layer>
+<Layer
+  onMouseDown={[Function]}
+  onMouseMove={[Function]}
+  onMouseUp={[Function]}
+>
+  <Rect
+    height={320}
+    width={1200}
+    x={0}
+    y={0}
+  />
   <Rect
     fill="#d86597"
     height={70}
@@ -15,6 +25,11 @@ exports[`renders correctly 1`] = `
     width={192}
     x={0}
     y={40}
+  />
+  <Rect
+    cornerRadius={3}
+    fill="#08b5d3"
+    opacity={0.4}
   />
 </Layer>
 `;

--- a/src/components/Composer/__snapshots__/SectionsLayer.test.js.snap
+++ b/src/components/Composer/__snapshots__/SectionsLayer.test.js.snap
@@ -2,9 +2,9 @@
 
 exports[`renders correctly 1`] = `
 <Layer
-  onMouseDown={[Function]}
-  onMouseMove={[Function]}
-  onMouseUp={[Function]}
+  onMouseDown={[MockFunction]}
+  onMouseMove={[MockFunction]}
+  onMouseUp={[MockFunction]}
 >
   <Rect
     height={320}

--- a/src/components/Composer/index.js
+++ b/src/components/Composer/index.js
@@ -55,7 +55,8 @@ export class ComposerContainer extends Component {
             trackInfoMenuTopScroll: 0,
             transportPosition: 0,
             stageWidth: windowWidth - 220,
-            stageHeight: windowHeight - 104
+            stageHeight: windowHeight - 104,
+            shiftKeyPressed: false
         };
     }
 
@@ -452,6 +453,14 @@ export class ComposerContainer extends Component {
         //console.log(e);
         e.stopPropagation();
 
+        if (e.key === 'Shift') {
+            if (!this.state.shiftKeyPressed) {
+                this.setState({
+                    shiftKeyPressed: true
+                });
+            }
+        }
+
         // handle deletion
         if (e.key === 'Delete') {
             this.handleSectionDeletion();
@@ -470,6 +479,17 @@ export class ComposerContainer extends Component {
         // handle clearing selection
         if (e.key === 'd' && e.ctrlKey) {
             this.clearCurrentSelection();
+        }
+    }
+
+    handleKeyUp = e => {
+        e.stopPropagation();
+        if (e.key === 'Shift') {
+            if (this.state.shiftKeyPressed) {
+                this.setState({
+                    shiftKeyPressed: false
+                });
+            }
         }
     }
 
@@ -608,6 +628,7 @@ export class ComposerContainer extends Component {
             cursorValue={this.state.pencilActive ? 'pencil' : 'pointer'}
             durationValue={this.state.sectionDuration}
             handleKeyDown={this.handleKeyDown}
+            handleKeyUp={this.handleKeyUp}
             updateCursorValue={this.updateCursorValue}
             updateDurationValue={this.updateSectionDurationValue}
             handleStageClick={this.handleStageClick}
@@ -623,6 +644,7 @@ export class ComposerContainer extends Component {
             currentlySelectedChannel={this.state.currentlySelectedChannel}
             updateSelectedChannel={this.updateSelectedChannel}
             handleScrollBarClickEvents={this.handleScrollBarClickEvents}
+            shiftKeyPressed={this.state.shiftKeyPressed}
         />
     }
 }

--- a/src/components/PianoRoll/NoteLayer.js
+++ b/src/components/PianoRoll/NoteLayer.js
@@ -1,46 +1,154 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { Layer, Rect } from 'react-konva';
 import PropTypes from 'prop-types';
 import { UIColors } from '../../constants';
+import { adjustForScroll } from '../../sharedUtils';
 
-const NoteLayer = props => (
-    <Layer
-        x={48}
-        y={40}
-        ref={props.noteLayerRef}
-    >
-        {props.sectionNotes.map((note, index) => (
-            <Rect 
-                x={note.x}
-                y={note.y}
-                width={note.width}
-                height={16}
-                stroke={UIColors.pink}
-                strokeWidth={2}
-                fill={props.currentlySelectedNotes.includes(note._id) ? 
-                    UIColors.darkGrey :
-                    '#ed90b9'
-                }
-                shadowColor={UIColors.pink}
-                shadowBlur={4}
-                shadowOffsetX={0}
-                shadowOffsetY={0}
-                pitch={note.pitch}
-                time={note.time}
-                _id={note._id}
-                type={'noteRect'}
-                key={note._id}
-                onClick={props.handleNoteClick}
-            />
-        ))}
-    </Layer>
-);
+class NoteLayer extends Component {
+    constructor(props) {
+        super(props);
+        this.overlayRectRef = React.createRef();
+        this.state = {
+            mouseIsDown: false,
+            mouseDownPosX: 0,
+            mouseDownPosY: 0,
+        }
+    }
+
+    handleMouseDown = (e) => {
+        this.setState({
+            mouseIsDown: true,
+            mouseDownPosX: adjustForScroll({ raw: e.evt.layerX, scroll: this.props.noteLayerRef.current.attrs.x }),
+            mouseDownPosY: adjustForScroll({ raw: e.evt.layerY, scroll: this.props.noteLayerRef.current.attrs.y })
+        });
+    }
+
+    handleMouseUp = (e) => {
+        this.setState({
+            mouseIsDown: false,
+            mouseDownPosX: 0,
+            mouseDownPosY: 0,
+            currentMousePosX: 0,
+            currentMousePosY: 0
+        });
+        const overlay = this.overlayRectRef.current;
+        overlay.x(0);
+        overlay.y(0);
+        overlay.width(0);
+        overlay.height(0);
+        this.props.noteLayerRef.current.batchDraw();
+    }
+
+    handleMouseMove = (e) => {
+        if (this.state.mouseIsDown && this.props.shiftKeyPressed) {
+            const currentMousePosX = adjustForScroll({ raw: e.evt.layerX, scroll: this.props.noteLayerRef.current.attrs.x });
+            const currentMousePosY = adjustForScroll({ raw: e.evt.layerY, scroll: this.props.noteLayerRef.current.attrs.y });
+            const { x, y, width, height } = this.getOverlayPosition({
+                mouseDownPosX: this.state.mouseDownPosX,
+                mouseDownPosY: this.state.mouseDownPosY,
+                currentMousePosX,
+                currentMousePosY,
+            });
+            const overlay = this.overlayRectRef.current;
+            overlay.x(x);
+            overlay.y(y);
+            overlay.width(width);
+            overlay.height(height);
+            this.props.noteLayerRef.current.batchDraw();
+        }
+    }
+
+    getOverlayPosition = (optionsObject) => {
+        const {
+            mouseDownPosX,
+            mouseDownPosY,
+            currentMousePosX,
+            currentMousePosY
+        } = optionsObject;
+        if (
+            mouseDownPosX === 0 && mouseDownPosY === 0 && 
+            currentMousePosX === 0 && currentMousePosY === 0
+        ) {
+            return {
+                x: 0,
+                y: 0,
+                width: 0,
+                height: 0
+            };
+        }
+        const leftBound = Math.min(mouseDownPosX, currentMousePosX);
+        const rightBound = Math.max(mouseDownPosX, currentMousePosX);
+        const topBound = Math.min(mouseDownPosY, currentMousePosY);
+        const bottomBound = Math.max(mouseDownPosY, currentMousePosY);
+        const width = rightBound - leftBound;
+        const height = bottomBound - topBound;
+        return {
+            x: leftBound,
+            y: topBound,
+            width,
+            height
+        };
+    }
+
+    render() {
+        return (
+            <Layer
+                x={48}
+                y={40}
+                ref={this.props.noteLayerRef}
+                onMouseDown={this.handleMouseDown}
+                onMouseUp={this.handleMouseUp}
+                onMouseMove={this.handleMouseMove}
+            >
+                <Rect 
+                    width={this.props.canvasWidth}
+                    height={this.props.canvasHeight}
+                    x={0}
+                    y={0}
+                />
+                {this.props.sectionNotes.map((note, index) => (
+                    <Rect 
+                        x={note.x}
+                        y={note.y}
+                        width={note.width}
+                        height={16}
+                        stroke={UIColors.pink}
+                        strokeWidth={2}
+                        fill={this.props.currentlySelectedNotes.includes(note._id) ? 
+                            UIColors.darkGrey :
+                            '#ed90b9'
+                        }
+                        shadowColor={UIColors.pink}
+                        shadowBlur={4}
+                        shadowOffsetX={0}
+                        shadowOffsetY={0}
+                        pitch={note.pitch}
+                        time={note.time}
+                        _id={note._id}
+                        type={'noteRect'}
+                        key={note._id}
+                        onClick={this.props.handleNoteClick}
+                    />
+                ))}
+                <Rect 
+                    ref={this.overlayRectRef}
+                    fill="#08b5d3"
+                    opacity={0.4}
+                    cornerRadius={3}
+                />
+            </Layer>
+        );
+    }
+}
 
 NoteLayer.propTypes = {
     noteLayerRef: PropTypes.object.isRequired,
     sectionNotes: PropTypes.arrayOf(PropTypes.object).isRequired,
     currentlySelectedNotes: PropTypes.arrayOf(PropTypes.string).isRequired,
-    handleNoteClick: PropTypes.func.isRequired
+    handleNoteClick: PropTypes.func.isRequired,
+    canvasHeight: PropTypes.number.isRequired,
+    canvasWidth: PropTypes.number.isRequired,
+    shiftKeyPressed: PropTypes.bool.isRequired
 };
 
 export default NoteLayer;

--- a/src/components/PianoRoll/NoteLayer.js
+++ b/src/components/PianoRoll/NoteLayer.js
@@ -1,145 +1,55 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Layer, Rect } from 'react-konva';
 import PropTypes from 'prop-types';
 import { UIColors } from '../../constants';
-import { adjustForScroll } from '../../sharedUtils';
 
-class NoteLayer extends Component {
-    constructor(props) {
-        super(props);
-        this.overlayRectRef = React.createRef();
-        this.state = {
-            mouseIsDown: false,
-            mouseDownPosX: 0,
-            mouseDownPosY: 0,
-        }
-    }
-
-    handleMouseDown = (e) => {
-        this.setState({
-            mouseIsDown: true,
-            mouseDownPosX: adjustForScroll({ raw: e.evt.layerX, scroll: this.props.noteLayerRef.current.attrs.x }),
-            mouseDownPosY: adjustForScroll({ raw: e.evt.layerY, scroll: this.props.noteLayerRef.current.attrs.y })
-        });
-    }
-
-    handleMouseUp = (e) => {
-        this.setState({
-            mouseIsDown: false,
-            mouseDownPosX: 0,
-            mouseDownPosY: 0,
-            currentMousePosX: 0,
-            currentMousePosY: 0
-        });
-        const overlay = this.overlayRectRef.current;
-        overlay.x(0);
-        overlay.y(0);
-        overlay.width(0);
-        overlay.height(0);
-        this.props.noteLayerRef.current.batchDraw();
-    }
-
-    handleMouseMove = (e) => {
-        if (this.state.mouseIsDown && this.props.shiftKeyPressed) {
-            const currentMousePosX = adjustForScroll({ raw: e.evt.layerX, scroll: this.props.noteLayerRef.current.attrs.x });
-            const currentMousePosY = adjustForScroll({ raw: e.evt.layerY, scroll: this.props.noteLayerRef.current.attrs.y });
-            const { x, y, width, height } = this.getOverlayPosition({
-                mouseDownPosX: this.state.mouseDownPosX,
-                mouseDownPosY: this.state.mouseDownPosY,
-                currentMousePosX,
-                currentMousePosY,
-            });
-            const overlay = this.overlayRectRef.current;
-            overlay.x(x);
-            overlay.y(y);
-            overlay.width(width);
-            overlay.height(height);
-            this.props.noteLayerRef.current.batchDraw();
-        }
-    }
-
-    getOverlayPosition = (optionsObject) => {
-        const {
-            mouseDownPosX,
-            mouseDownPosY,
-            currentMousePosX,
-            currentMousePosY
-        } = optionsObject;
-        if (
-            mouseDownPosX === 0 && mouseDownPosY === 0 && 
-            currentMousePosX === 0 && currentMousePosY === 0
-        ) {
-            return {
-                x: 0,
-                y: 0,
-                width: 0,
-                height: 0
-            };
-        }
-        const leftBound = Math.min(mouseDownPosX, currentMousePosX);
-        const rightBound = Math.max(mouseDownPosX, currentMousePosX);
-        const topBound = Math.min(mouseDownPosY, currentMousePosY);
-        const bottomBound = Math.max(mouseDownPosY, currentMousePosY);
-        const width = rightBound - leftBound;
-        const height = bottomBound - topBound;
-        return {
-            x: leftBound,
-            y: topBound,
-            width,
-            height
-        };
-    }
-
-    render() {
-        return (
-            <Layer
-                x={48}
-                y={40}
-                ref={this.props.noteLayerRef}
-                onMouseDown={this.handleMouseDown}
-                onMouseUp={this.handleMouseUp}
-                onMouseMove={this.handleMouseMove}
-            >
-                <Rect 
-                    width={this.props.canvasWidth}
-                    height={this.props.canvasHeight}
-                    x={0}
-                    y={0}
-                />
-                {this.props.sectionNotes.map((note, index) => (
-                    <Rect 
-                        x={note.x}
-                        y={note.y}
-                        width={note.width}
-                        height={16}
-                        stroke={UIColors.pink}
-                        strokeWidth={2}
-                        fill={this.props.currentlySelectedNotes.includes(note._id) ? 
-                            UIColors.darkGrey :
-                            '#ed90b9'
-                        }
-                        shadowColor={UIColors.pink}
-                        shadowBlur={4}
-                        shadowOffsetX={0}
-                        shadowOffsetY={0}
-                        pitch={note.pitch}
-                        time={note.time}
-                        _id={note._id}
-                        type={'noteRect'}
-                        key={note._id}
-                        onClick={this.props.handleNoteClick}
-                    />
-                ))}
-                <Rect 
-                    ref={this.overlayRectRef}
-                    fill="#08b5d3"
-                    opacity={0.4}
-                    cornerRadius={3}
-                />
-            </Layer>
-        );
-    }
-}
+const NoteLayer = props => (
+    <Layer
+        x={48}
+        y={40}
+        ref={props.noteLayerRef}
+        onMouseDown={props.handleMouseDown}
+        onMouseUp={props.handleMouseUp}
+        onMouseMove={props.handleMouseMove}
+    >
+        <Rect 
+            width={props.canvasWidth}
+            height={props.canvasHeight}
+            x={0}
+            y={0}
+        />
+        {props.sectionNotes.map((note, index) => (
+            <Rect 
+                x={note.x}
+                y={note.y}
+                width={note.width}
+                height={16}
+                stroke={UIColors.pink}
+                strokeWidth={2}
+                fill={props.currentlySelectedNotes.includes(note._id) ? 
+                    UIColors.darkGrey :
+                    '#ed90b9'
+                }
+                shadowColor={UIColors.pink}
+                shadowBlur={4}
+                shadowOffsetX={0}
+                shadowOffsetY={0}
+                pitch={note.pitch}
+                time={note.time}
+                _id={note._id}
+                type={'noteRect'}
+                key={note._id}
+                onClick={props.handleNoteClick}
+            />
+        ))}
+        <Rect 
+            ref={props.overlayRectRef}
+            fill="#08b5d3"
+            opacity={0.4}
+            cornerRadius={3}
+        />
+    </Layer>
+);
 
 NoteLayer.propTypes = {
     noteLayerRef: PropTypes.object.isRequired,
@@ -148,7 +58,10 @@ NoteLayer.propTypes = {
     handleNoteClick: PropTypes.func.isRequired,
     canvasHeight: PropTypes.number.isRequired,
     canvasWidth: PropTypes.number.isRequired,
-    shiftKeyPressed: PropTypes.bool.isRequired
+    handleMouseDown: PropTypes.func.isRequired,
+    handleMouseUp: PropTypes.func.isRequired,
+    handleMouseMove: PropTypes.func.isRequired,
+    overlayRectRef: PropTypes.object.isRequired
 };
 
 export default NoteLayer;

--- a/src/components/PianoRoll/NoteLayer.test.js
+++ b/src/components/PianoRoll/NoteLayer.test.js
@@ -133,6 +133,9 @@ test('renders correctly', () => {
             handleNoteClick={jest.fn()}
             sectionNotes={notesState}
             currentlySelectedNotes={[]}
+            canvasHeight={600}
+            canvasWidth={650}
+            shiftKeyPressed={false}
         />
     );
     expect(component).toMatchSnapshot();
@@ -145,6 +148,9 @@ test('renders selected notes with a different fill color', () => {
             handleNoteClick={jest.fn()}
             sectionNotes={notesState}
             currentlySelectedNotes={['5675315161385905']}
+            canvasHeight={600}
+            canvasWidth={650}
+            shiftKeyPressed={false}
         />
     );
     const selectedNoteWrapper = component.find({ _id: '5675315161385905' });

--- a/src/components/PianoRoll/NoteLayer.test.js
+++ b/src/components/PianoRoll/NoteLayer.test.js
@@ -130,12 +130,15 @@ test('renders correctly', () => {
     const component = shallow(
         <NoteLayer 
             noteLayerRef={React.createRef()}
-            handleNoteClick={jest.fn()}
             sectionNotes={notesState}
             currentlySelectedNotes={[]}
+            handleNoteClick={jest.fn()}
             canvasHeight={600}
             canvasWidth={650}
-            shiftKeyPressed={false}
+            handleMouseDown={jest.fn()}
+            handleMouseUp={jest.fn()}
+            handleMouseMove={jest.fn()}
+            overlayRectRef={React.createRef()}
         />
     );
     expect(component).toMatchSnapshot();
@@ -150,7 +153,10 @@ test('renders selected notes with a different fill color', () => {
             currentlySelectedNotes={['5675315161385905']}
             canvasHeight={600}
             canvasWidth={650}
-            shiftKeyPressed={false}
+            handleMouseDown={jest.fn()}
+            handleMouseUp={jest.fn()}
+            handleMouseMove={jest.fn()}
+            overlayRectRef={React.createRef()}
         />
     );
     const selectedNoteWrapper = component.find({ _id: '5675315161385905' });

--- a/src/components/PianoRoll/PianoRoll.js
+++ b/src/components/PianoRoll/PianoRoll.js
@@ -9,6 +9,7 @@ import PianoKeyLayer from './PianoKeyLayer';
 import TransportLayer from './TransportLayer';
 import SeekerLayer from './SeekerLayer';
 import ScrollBarLayer from './ScrollBarLayer';
+import SelectionOverlayEnhancer from '../SelectionOverlayEnhancer'
 
 const PianoRoll = props => (
     <div 
@@ -45,15 +46,19 @@ const PianoRoll = props => (
                     canvasWidth={props.canvasWidth}
                     gridLinesArray={props.gridLinesArray}
                 />
-                <NoteLayer 
+                
+                <SelectionOverlayEnhancer
+                    childLayerRef={props.noteLayerRef}
+                    shiftKeyPressed={props.shiftKeyPressed}
                     noteLayerRef={props.noteLayerRef}
                     sectionNotes={props.section.notes}
                     currentlySelectedNotes={props.currentlySelectedNotes}
                     handleNoteClick={props.handleNoteClick}
                     canvasWidth={props.canvasWidth}
                     canvasHeight={props.canvasHeight}
-                    shiftKeyPressed={props.shiftKeyPressed}
-                />
+                >
+                    {props => <NoteLayer {...props} />}
+                </SelectionOverlayEnhancer>
                 <VelocityLayer 
                     stageHeight={props.stageHeight}
                     velocityLayerRef={props.velocityLayerRef}

--- a/src/components/PianoRoll/PianoRoll.js
+++ b/src/components/PianoRoll/PianoRoll.js
@@ -15,6 +15,7 @@ const PianoRoll = props => (
         className="piano-roll__container" 
         tabIndex="-1" 
         onKeyDown={props.handleKeyDown}
+        onKeyUp={props.handleKeyUp}
         style={{outline: 'none'}}
         ref={props.outerContainerRef}
     >
@@ -25,6 +26,8 @@ const PianoRoll = props => (
             updateDurationValue={props.updateDurationValue}
             cursorValue={props.cursorValue}
             updateCursorValue={props.updateCursorValue}
+            currentMousePosX={props.currentMousePosX}
+            currentMousePosY={props.currentMousePosY}
         />
         <div className="piano-roll__canvas-container" id="piano-roll-canvas-container">
             <Stage 
@@ -35,6 +38,7 @@ const PianoRoll = props => (
                 onClick={props.handleStageClick}
                 onMouseDown={props.handleMouseDown} 
                 onMouseUp={props.handleMouseUp}
+                onMouseMove={props.handleMouseMove}
             >
                 <GridLayer 
                     gridLayerRef={props.gridLayerRef}
@@ -46,6 +50,9 @@ const PianoRoll = props => (
                     sectionNotes={props.section.notes}
                     currentlySelectedNotes={props.currentlySelectedNotes}
                     handleNoteClick={props.handleNoteClick}
+                    canvasWidth={props.canvasWidth}
+                    canvasHeight={props.canvasHeight}
+                    shiftKeyPressed={props.shiftKeyPressed}
                 />
                 <VelocityLayer 
                     stageHeight={props.stageHeight}
@@ -107,18 +114,21 @@ PianoRoll.propTypes = {
     unselectedNotes: PropTypes.arrayOf(PropTypes.object).isRequired,
     pitchesArray: PropTypes.arrayOf(PropTypes.string).isRequired,
     transportBarNumbersArray: PropTypes.arrayOf(PropTypes.object).isRequired,
-    // input values
+    // values from state
     quantizeValue: PropTypes.string.isRequired,
     durationValue: PropTypes.string.isRequired,
     cursorValue: PropTypes.string.isRequired,
+    shiftKeyPressed: PropTypes.bool.isRequired,
     // callback functions
     handleKeyDown: PropTypes.func.isRequired,
+    handleKeyUp: PropTypes.func.isRequired,
     updateQuantizeValue: PropTypes.func.isRequired,
     updateDurationValue: PropTypes.func.isRequired,
     updateCursorValue: PropTypes.func.isRequired,
     handleStageClick: PropTypes.func.isRequired,
     handleMouseDown: PropTypes.func.isRequired,
     handleMouseUp: PropTypes.func.isRequired,
+    handleMouseMove: PropTypes.func.isRequired,
     handleNoteClick: PropTypes.func.isRequired,
     handleVelocityLayerClick: PropTypes.func.isRequired,
     handlePianoKeyClick: PropTypes.func.isRequired,
@@ -127,6 +137,7 @@ PianoRoll.propTypes = {
     handleScrollBarClickEvents: PropTypes.func.isRequired,
     // reference to the section object from redux store
     section: PropTypes.object.isRequired  
+
 };
 
 export default PianoRoll;

--- a/src/components/PianoRoll/__snapshots__/NoteLayer.test.js.snap
+++ b/src/components/PianoRoll/__snapshots__/NoteLayer.test.js.snap
@@ -2,9 +2,9 @@
 
 exports[`renders correctly 1`] = `
 <Layer
-  onMouseDown={[Function]}
-  onMouseMove={[Function]}
-  onMouseUp={[Function]}
+  onMouseDown={[MockFunction]}
+  onMouseMove={[MockFunction]}
+  onMouseUp={[MockFunction]}
   x={48}
   y={40}
 >

--- a/src/components/PianoRoll/__snapshots__/NoteLayer.test.js.snap
+++ b/src/components/PianoRoll/__snapshots__/NoteLayer.test.js.snap
@@ -2,9 +2,18 @@
 
 exports[`renders correctly 1`] = `
 <Layer
+  onMouseDown={[Function]}
+  onMouseMove={[Function]}
+  onMouseUp={[Function]}
   x={48}
   y={40}
 >
+  <Rect
+    height={600}
+    width={650}
+    x={0}
+    y={0}
+  />
   <Rect
     _id="5675315161385905"
     fill="#ed90b9"
@@ -232,6 +241,11 @@ exports[`renders correctly 1`] = `
     width={240}
     x={528}
     y={864}
+  />
+  <Rect
+    cornerRadius={3}
+    fill="#08b5d3"
+    opacity={0.4}
   />
 </Layer>
 `;

--- a/src/components/PianoRoll/__snapshots__/PianoRoll.test.js.snap
+++ b/src/components/PianoRoll/__snapshots__/PianoRoll.test.js.snap
@@ -3399,9 +3399,14 @@ exports[`renders correctly 2`] = `
           ]
         }
       />
-      <NoteLayer
+      <SelectionOverlayEnhancer
         canvasHeight={1768}
         canvasWidth={1536}
+        childLayerRef={
+          Object {
+            "current": null,
+          }
+        }
         currentlySelectedNotes={Array []}
         handleNoteClick={[Function]}
         noteLayerRef={
@@ -3411,7 +3416,9 @@ exports[`renders correctly 2`] = `
         }
         sectionNotes={Array []}
         shiftKeyPressed={false}
-      />
+      >
+        <Component />
+      </SelectionOverlayEnhancer>
       <VelocityLayer
         canvasWidth={1536}
         handleVelocityLayerClick={[Function]}

--- a/src/components/PianoRoll/__snapshots__/PianoRoll.test.js.snap
+++ b/src/components/PianoRoll/__snapshots__/PianoRoll.test.js.snap
@@ -1583,7 +1583,9 @@ exports[`renders correctly 1`] = `
     ]
   }
   handleKeyDown={[Function]}
+  handleKeyUp={[Function]}
   handleMouseDown={[Function]}
+  handleMouseMove={[Function]}
   handleMouseUp={[Function]}
   handleNoteClick={[Function]}
   handlePianoKeyClick={[Function]}
@@ -1740,6 +1742,7 @@ exports[`renders correctly 1`] = `
     }
   }
   selectedNotes={Array []}
+  shiftKeyPressed={false}
   stageHeight={600}
   stageRef={
     Object {
@@ -1789,6 +1792,7 @@ exports[`renders correctly 2`] = `
 <div
   className="piano-roll__container"
   onKeyDown={[Function]}
+  onKeyUp={[Function]}
   style={
     Object {
       "outline": "none",
@@ -1813,6 +1817,7 @@ exports[`renders correctly 2`] = `
       height={600}
       onClick={[Function]}
       onMouseDown={[Function]}
+      onMouseMove={[Function]}
       onMouseUp={[Function]}
       width={800}
     >
@@ -3395,6 +3400,8 @@ exports[`renders correctly 2`] = `
         }
       />
       <NoteLayer
+        canvasHeight={1768}
+        canvasWidth={1536}
         currentlySelectedNotes={Array []}
         handleNoteClick={[Function]}
         noteLayerRef={
@@ -3403,6 +3410,7 @@ exports[`renders correctly 2`] = `
           }
         }
         sectionNotes={Array []}
+        shiftKeyPressed={false}
       />
       <VelocityLayer
         canvasWidth={1536}

--- a/src/components/PianoRoll/index.js
+++ b/src/components/PianoRoll/index.js
@@ -103,12 +103,16 @@ export class PianoRollContainer extends Component {
             duration: '16n',
             mouseDownPosX: 0,
             mouseDownPosY: 0,
+            currentMousePosX: 0,
+            currentMousePosY : 0,
             pencilActive: false,
             stageWidth: 800,
             stageHeight: 600,
             scrollBarActive: false,
             currentlySelectedNotes: [],
             currentlyCopiedNotes: null,
+            shiftKeyPressed: false,
+            mouseIsDown: false
         };
     }
 
@@ -235,10 +239,11 @@ export class PianoRollContainer extends Component {
             this.setState({ scrollBarActive: false });
             return;
         }
+
         // if a note was clicked on just return, the onClick handler already contains all of the
         // logic for that. 
         if (e.target.attrs.type && e.target.attrs.type === 'noteRect') {
-            return;
+            //return;
         }
         // As long as the mouse down event occurred on the main part of the canvas, update mouseDownPosX and
         // mouseDownPosY with values derived from the event. If the event occurred on the transport section
@@ -275,6 +280,15 @@ export class PianoRollContainer extends Component {
         }
     }
 
+    handleMouseMove = e => {
+        if (this.state.mouseIsDown && this.state.shiftKeyPressed) {
+            this.setState({
+                currentMousePosX: adjustForScroll({ raw: e.evt.layerX, scroll: this.gridLayerRef.current.attrs.x }),
+                currentMousePosY: adjustForScroll({ raw: e.evt.layerY, scroll: this.gridLayerRef.current.attrs.y })
+            });
+        }
+    }
+
     /**
      * The main function for handling keyDown events on this component, delegates to other functions
      * as necessary.
@@ -283,6 +297,14 @@ export class PianoRollContainer extends Component {
     handleKeyDown = e => {
         e.preventDefault();
         e.stopPropagation();
+
+        if (e.key === 'Shift') {
+            if (!this.state.shiftKeyPressed) {
+                this.setState({
+                    shiftKeyPressed: true
+                });
+            }
+        }
 
         // handle deletion
         if (e.key === 'Delete') {
@@ -334,6 +356,21 @@ export class PianoRollContainer extends Component {
         // handle clearing selection
         if (e.key === 'd' && e.ctrlKey) {
             this.clearCurrentSelection();
+        }
+
+
+    }
+
+    handleKeyUp = e => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        if (e.key === 'Shift') {
+            if (this.state.shiftKeyPressed) {
+                this.setState({
+                    shiftKeyPressed: false
+                });
+            }
         }
     }
 
@@ -846,6 +883,7 @@ export class PianoRollContainer extends Component {
 
         return <PianoRoll 
             handleKeyDown={this.handleKeyDown}
+            handleKeyUp={this.handleKeyUp}
             outerContainerRef={this.outerContainerRef}
             quantizeValue={this.state.quantize}
             updateQuantizeValue={this.updateQuantizeValue.bind(this)}
@@ -857,6 +895,7 @@ export class PianoRollContainer extends Component {
             handleStageClick={this.handleStageClick}
             handleMouseDown={this.handleMouseDown}
             handleMouseUp={this.handleMouseUp}
+            handleMouseMove={this.handleMouseMove}
             gridLayerRef={this.gridLayerRef}
             canvasWidth={this.canvasWidth}
             canvasHeight={this.canvasHeight}
@@ -882,6 +921,7 @@ export class PianoRollContainer extends Component {
             horizontalDragMove={this.horizontalDragMove}
             verticalDragMove={this.verticalDragMove}
             handleScrollBarClickEvents={this.handleScrollBarClickEvents}
+            shiftKeyPressed={this.state.shiftKeyPressed}
         />
     }
 

--- a/src/components/SelectionOverlayEnhancer/index.js
+++ b/src/components/SelectionOverlayEnhancer/index.js
@@ -1,0 +1,123 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { adjustForScroll } from '../../sharedUtils';
+import { getOverlayPosition } from './utils';
+
+/*
+This component enhances a canvas layer component by adding the logic to control a visual selection overlay
+on that layer. This overlay will show when the shift key is pressed and the mouse is down. 
+
+Keeping track of whether or not the shift key is pressed is not handled by this component, so the main canvas
+component that renders this component should keep track of the shift keys status. 
+
+This component also requires a reference (a React ref) to the canvas layer that it is rendering as its child. 
+This is because it needs to call the batchDraw method on that layer to update the overlay, and it needs to be 
+able to check the current scrolling for that layer in order to adjust its calculations. 
+
+
+Constraints on the child component:
+
+It must render a Konva.Layer component. 
+It must contain accept an overlayRectRef prop, which is a React ref. It must then render a Konva.Rect and set 
+overlayRectRef as its ref, this is in order to allow the SelectionOverlayEnhancer component to make changes to
+the rect node directly. 
+
+Because Konva events originate from canvas elements rather than the layers, the layer rendered by the child 
+component cannot be an empty/partially empty layer, or else the mouse events won't render when they occur over
+any of the 'gaps'. If the canvas layer does not have any kind of background etc to give it complete coverage, 
+an invisible Rect can be added to the layer so that mouse events will still register. 
+
+*/
+
+
+class SelectionOverlayEnhancer extends Component {
+    constructor(props) {
+        super(props);
+        this.overlayRectRef = React.createRef();
+        this.state = {
+            mouseIsDown: false,
+            mouseDownPosX: 0,
+            mouseDownPosY: 0,
+        }
+    }
+
+    /**
+     * Handles mouseDown events by updating state with the new mouseIsDown status and the x and y coords of the
+     * mouseDown event.
+     * @param {object} e - the event object.
+     */
+    handleMouseDown = (e) => {
+        this.setState({
+            mouseIsDown: true,
+            mouseDownPosX: adjustForScroll({ raw: e.evt.layerX, scroll: this.props.childLayerRef.current.attrs.x }),
+            mouseDownPosY: adjustForScroll({ raw: e.evt.layerY, scroll: this.props.childLayerRef.current.attrs.y })
+        });
+    }
+
+    /**
+     * Handles mouseUp events. Sets state back to its default values. Hides the overlayRect node and calls
+     * batchDraw on the child canvas layer.
+     * @param {object} e - the event object. 
+     */
+    handleMouseUp = (e) => {
+        this.setState({
+            mouseIsDown: false,
+            mouseDownPosX: 0,
+            mouseDownPosY: 0,
+        });
+        const overlay = this.overlayRectRef.current;
+        overlay.x(0);
+        overlay.y(0);
+        overlay.width(0);
+        overlay.height(0);
+        this.props.childLayerRef.current.batchDraw();
+    }
+
+    /**
+     * Handles mouseMove events. If the conditions are met for a selection overlay to be shown, it updates the 
+     * overlayRect node with new values based off of the x and y coords for the last recorded mouseDown event, 
+     * and the x and y coords of the current mouse position.
+     * @param {object} e - the event object.
+     */
+    handleMouseMove = (e) => {
+        if (this.state.mouseIsDown && this.props.shiftKeyPressed) {
+            const currentMousePosX = adjustForScroll({ raw: e.evt.layerX, scroll: this.props.childLayerRef.current.attrs.x });
+            const currentMousePosY = adjustForScroll({ raw: e.evt.layerY, scroll: this.props.childLayerRef.current.attrs.y });
+            const { x, y, width, height } = getOverlayPosition({
+                mouseDownPosX: this.state.mouseDownPosX,
+                mouseDownPosY: this.state.mouseDownPosY,
+                currentMousePosX,
+                currentMousePosY,
+            });
+            const overlay = this.overlayRectRef.current;
+            overlay.x(x);
+            overlay.y(y);
+            overlay.width(width);
+            overlay.height(height);
+            this.props.childLayerRef.current.batchDraw();
+        }
+    }
+
+    render() {
+        const { 
+            children, 
+            childLayerRef,
+            shiftKeyPressed,
+            ...passedProps 
+        } = this.props;
+        return children({
+            handleMouseDown: this.handleMouseDown,
+            handleMouseUp: this.handleMouseUp,
+            handleMouseMove: this.handleMouseMove,
+            overlayRectRef: this.overlayRectRef,
+            ...passedProps
+        });
+    }
+}
+
+SelectionOverlayEnhancer.propTypes = {
+    childLayerRef: PropTypes.object.isRequired,
+    shiftKeyPressed: PropTypes.bool.isRequired
+};
+
+export default SelectionOverlayEnhancer;

--- a/src/components/SelectionOverlayEnhancer/utils.js
+++ b/src/components/SelectionOverlayEnhancer/utils.js
@@ -1,0 +1,31 @@
+/**
+ * Given x and y coords for a mouseDown event, and x and y coords for the current mouse position, determines
+ * the x, y, width and height parameters needed to create a rectangle matching the selection described by the
+ * coordinates, and returns those parameters as an object. 
+ * @param {number} mouseDownPosX - the x coord of the last mouseDown event
+ * @param {number} mouseDownPosY - the y coord of the last mouseDown event
+ * @param {number} currentMousePosX - the x coord of the current mouse position
+ * @param {number} currentMousePosY - the y coord of the current mouse position
+ * @returns {object} - an object with x, y, width and height properties to render a rectangle with. 
+ */
+export const getOverlayPosition = (optionsObject) => {
+    const {
+        mouseDownPosX,
+        mouseDownPosY,
+        currentMousePosX,
+        currentMousePosY
+    } = optionsObject;
+    
+    const leftBound = Math.min(mouseDownPosX, currentMousePosX);
+    const rightBound = Math.max(mouseDownPosX, currentMousePosX);
+    const topBound = Math.min(mouseDownPosY, currentMousePosY);
+    const bottomBound = Math.max(mouseDownPosY, currentMousePosY);
+    const width = rightBound - leftBound;
+    const height = bottomBound - topBound;
+    return {
+        x: leftBound,
+        y: topBound,
+        width,
+        height
+    };
+};

--- a/src/components/SelectionOverlayEnhancer/utils.test.js
+++ b/src/components/SelectionOverlayEnhancer/utils.test.js
@@ -1,0 +1,34 @@
+import { getOverlayPosition } from './utils';
+
+describe('getOverlayPosition', () => {
+    test('returns the correct attrs when current pos is greater than starting pos', () => {
+        const result = getOverlayPosition({
+            mouseDownPosX: 16,
+            mouseDownPosY: 24,
+            currentMousePosX: 32,
+            currentMousePosY: 48
+        });
+        const expectedResult = {
+            x: 16,
+            y: 24,
+            width: 16,
+            height: 24
+        };
+        expect(result).toEqual(expectedResult);
+    });
+    test('returns the correct attrs when current pos is less than starting pos', () => {
+        const result = getOverlayPosition({
+            mouseDownPosX: 28,
+            mouseDownPosY: 46,
+            currentMousePosX: 18,
+            currentMousePosY: 22
+        });
+        const expectedResult = {
+            x: 18,
+            y: 22,
+            width: 10,
+            height: 24
+        };
+        expect(result).toEqual(expectedResult);
+    });
+});


### PR DESCRIPTION
Added selection range highlighting logic which renders a semi-transparent overlay over the currently selected area of a canvas. The logic has been added as an enhancer component which uses render props to render a child canvas layer component. This enhancer component can be reused across different canvas contexts. 